### PR TITLE
Add support for on_set callback to `BaseField`

### DIFF
--- a/dirty_models/fields.py
+++ b/dirty_models/fields.py
@@ -30,7 +30,7 @@ class BaseField:
         self.metadata = metadata
         self._getter = getter
         self._setter = setter
-        self._on_set = on_set
+        self._on_set = on_set if (on_set is None or isinstance(on_set, (list, tuple))) else [on_set]
         self.__doc__ = doc or self.get_field_docstring()
 
     def get_field_docstring(self):
@@ -119,8 +119,9 @@ class BaseField:
 
         set_value(value)
 
-        if callable(self._on_set):
-            self._on_set(obj, self.name)
+        if self._on_set:
+            for cb in self._on_set:
+                cb(obj, self.name)
 
     def __delete__(self, obj):
         self._check_name()

--- a/dirty_models/fields.py
+++ b/dirty_models/fields.py
@@ -20,7 +20,7 @@ class BaseField:
     """Base field descriptor."""
 
     def __init__(self, name=None, alias=None, getter=None, setter=None, read_only=False,
-                 default=None, title=None, doc=None, metadata=None):
+                 default=None, title=None, doc=None, metadata=None, on_set=None):
         self._name = None
         self.name = name
         self.alias = alias
@@ -30,6 +30,7 @@ class BaseField:
         self.metadata = metadata
         self._getter = getter
         self._setter = setter
+        self._on_set = on_set
         self.__doc__ = doc or self.get_field_docstring()
 
     def get_field_docstring(self):
@@ -117,6 +118,9 @@ class BaseField:
                 set_value(v())
 
         set_value(value)
+
+        if callable(self._on_set):
+            self._on_set(obj, self.name)
 
     def __delete__(self, obj):
         self._check_name()

--- a/tests/dirty_models/tests_models.py
+++ b/tests/dirty_models/tests_models.py
@@ -525,6 +525,19 @@ class TestModels(TestCase):
 
         self.assertEqual(model_object.testField1.testBaseField1, 'setter_function')
 
+    def test_object_model_field_with_on_set_callback(self):
+        def update_testField2(model_object, field_name):
+            model_object.testField2 = field_name
+
+        class FakeModel(BaseModel):
+            testField1 = BaseField(on_set=update_testField2)
+            testField2 = BaseField()
+
+        model_object = FakeModel()
+        self.assertIsNone(model_object.testField2)
+        model_object.testField1 = "Value1"
+        self.assertEqual(model_object.testField2, "testField1")
+
     def test_get_field_obj(self):
         class FakeModel(BaseModel):
             testField1 = BaseField()


### PR DESCRIPTION
It's nice to be able to override the setter for the model's field, but if I don't want to change the logic of setting value itself, but only execute some extra code when a value is set, there's no quick and easy way to do this with the setter (it's possible, but to keep the same logic, one needs to basically copy part of the code from `BaseField`'s `__set__` method.

This PR adds an `on_set` callback to `BaseField`. If it is set and the setter is not set, it's called after the value has been set on the field, with model object and current field name being passed as arguments.

Here's an example of automatically updating another field when one of the fields has been changed:
```python
import datetime
from time import sleep
from dirty_models import BaseModel, StringField, DateTimeField


def update_last_status_change(obj, field_name):
    if obj.is_modified_field(field_name):
        obj.last_status_change = datetime.datetime.now()


class SomeModel(BaseModel):
    status = StringField(on_set=update_last_status_change)
    last_status_change = DateTimeField()


obj = SomeModel(status=1)
timestamp = obj.last_status_change
sleep(1)
obj.status = 2
assert obj.last_status_change > timestamp
```