### PR TITLE
Provide default field setter implementation as a separate class

### DIFF
--- a/dirty_models/fields.py
+++ b/dirty_models/fields.py
@@ -21,6 +21,11 @@ class BaseField:
 
     def __init__(self, name=None, alias=None, getter=None, setter=None, read_only=False,
                  default=None, title=None, doc=None, metadata=None):
+
+        if setter is None or not callable(setter):
+            from .utils import default_setter
+            setter = default_setter
+
         self._name = None
         self.name = name
         self.alias = alias
@@ -101,22 +106,7 @@ class BaseField:
 
     def __set__(self, obj, value):
         self._check_name()
-
-        if self._setter:
-            self._setter(self, obj, value)
-            return
-
-        from dirty_models.utils import Factory
-
-        def set_value(v):
-            if value is None:
-                self.delete_value(obj)
-            elif self.check_value(v) or self.can_use_value(v):
-                self.set_value(obj, self.use_value(v))
-            elif isinstance(value, Factory):
-                set_value(v())
-
-        set_value(value)
+        self._setter(self, obj, value)
 
     def __delete__(self, obj):
         self._check_name()

--- a/dirty_models/utils.py
+++ b/dirty_models/utils.py
@@ -9,7 +9,7 @@ from .fields import MultiTypeField
 from .model_types import ListModel
 from .models import BaseModel
 
-__all__ = ['factory', 'JSONEncoder', 'Factory']
+__all__ = ['factory', 'JSONEncoder', 'Factory', 'Setter', 'default_setter']
 
 
 def underscore_to_camel(string):
@@ -151,3 +151,24 @@ class Factory:
 
 
 factory = Factory
+
+
+class Setter:
+    """
+    Default implementation for model field's setter.
+    """
+
+    def __call__(self, field, obj, value):
+
+        def set_value(v):
+            if value is None:
+                field.delete_value(obj)
+            elif field.check_value(v) or field.can_use_value(v):
+                field.set_value(obj, field.use_value(v))
+            elif isinstance(value, Factory):
+                set_value(v())
+
+        set_value(value)
+
+
+default_setter = Setter()


### PR DESCRIPTION
This PR extracts default setter implementation from `BaseField`'s `__set__` method into a separate `dirty_models.utils.Setter` class. As the Setter is stateless, a singleton instance of Setter (`dirty_models.utils.default_setter`) is also created. If `None` (default) or non-callable object is passed to `BaseField`'s `__init__` method, a default_setter is used, providing default behaviour.

This also makes possible to inherit from the Setter to provide augmented functionality. Here's an example of a `CallbackSetter` class, which calls callbacks before and after setting a value using default setter:

```python
import datetime
from functools import partial
from dirty_models import BaseModel, StringField, DateTimeField
from dirty_models.utils import Setter


class CallbackSetter(Setter):

    def __init__(self, before=None, after=None):
        if before is None:
            self._before = []
        elif not isinstance(before, (list, tuple)):
            self._before = [before]

        self._before = [func for func in self._before if callable(func)]

        if after is None:
            self._after = []
        elif not isinstance(after, (list, tuple)):
            self._after = [after]

        self._after = [func for func in self._after if callable(func)]

    def __call__(self, descriptor, obj, value):
        for func in self._before:
            func(descriptor, obj, value)

        super().__call__(descriptor, obj, value)

        for func in self._after:
            func(descriptor, obj, value)


def update_last_changed_field(dt_field_name, field, obj, value):
    if obj.is_modified_field(field.name):
        setattr(obj, dt_field_name, datetime.datetime.now())


class TestModel(BaseModel):
    field1 = StringField(setter=CallbackSetter(after=partial(update_last_changed_field, 'field1_last_changed')))
    field1_last_changed = DateTimeField()


obj = TestModel()
obj.field1 = "test"

print(obj)
```
